### PR TITLE
Fixed requirements error in registration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ authorizenet
 Whoosh
 SQLAlchemy
 pymysql
+email-validator


### PR DESCRIPTION
Added a package that was implicitly loaded on our IDEs be needed to be explicit on AWS (email-validator) to get the new donor registration to run on the EC2 instance. Also fixed static image folder permissions with sudo chmod -R 775 static/images
so that images can be uploaded, resolving the issue of new campaigns on the AWS version caused by the image upload.